### PR TITLE
商品情報編集機能_r3

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :item_of_current_user?, only: [:edit, :update]
+  before_action :find_item_by_id, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       render action: :show
     else
@@ -43,8 +41,12 @@ class ItemsController < ApplicationController
                                  :price).merge(user_id: current_user.id)
   end
 
+  def find_item_by_id
+    @item=Item.find(params[:id])
+  end
+
   def item_of_current_user?
-    item = Item.find(params[:id])
-    redirect_to root_path if current_user != item.user
+    find_item_by_id
+    redirect_to root_path if current_user != @item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :item_of_current_user?, only: [:edit, :update]
   before_action :find_item_by_id, only: [:show, :edit, :update]
+  before_action :item_of_current_user?, only: [:edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -42,11 +42,10 @@ class ItemsController < ApplicationController
   end
 
   def find_item_by_id
-    @item=Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def item_of_current_user?
-    find_item_by_id
     redirect_to root_path if current_user != @item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,11 +24,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item=Item.find(params[:id])
+    @item = Item.find(params[:id])
   end
 
   def update
-    @item=Item.find(params[:id])
+    @item = Item.find(params[:id])
     if @item.update(item_params)
       render action: :show
     else
@@ -44,9 +44,7 @@ class ItemsController < ApplicationController
   end
 
   def item_of_current_user?
-    item=Item.find(params[:id])
-    if current_user!=item.user
-      redirect_to root_path
-    end
+    item = Item.find(params[:id])
+    redirect_to root_path if current_user != item.user
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :item_of_current_user?, only: [:edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -22,10 +23,30 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item=Item.find(params[:id])
+  end
+
+  def update
+    @item=Item.find(params[:id])
+    if @item.update(item_params)
+      render action: :show
+    else
+      render action: :edit
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:name, :image, :description, :category_id, :condition_id, :charge_id, :prefecture_id, :day_id,
                                  :price).merge(user_id: current_user.id)
+  end
+
+  def item_of_current_user?
+    item=Item.find(params[:id])
+    if current_user!=item.user
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -5,11 +5,10 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, url: item_path(@item.id), local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
       <%= render partial: "shared/error_messages", locals: {model: f.object} %>
 
-      <%# 出品画像 %>
       <div class="img-upload">
         <div class="weight-bold-text">
           出品画像
@@ -22,8 +21,6 @@
           <%= f.file_field :image, id:"item-image" %>
         </div>
       </div>
-      <%# /出品画像 %>
-      <%# 商品名と商品説明 %>
       <div class="new-items">
         <div class="weight-bold-text">
           商品名
@@ -38,9 +35,7 @@
           <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-      <%# /商品名と商品説明 %>
 
-      <%# 商品の詳細 %>
       <div class="items-detail">
         <div class="weight-bold-text">商品の詳細</div>
         <div class="form">
@@ -56,9 +51,7 @@
           <%= f.collection_select(:condition_id, Condition.all, :id, :condition, {}, {class:"select-box", id:"item-sales-status"}) %>
         </div>
       </div>
-      <%# /商品の詳細 %>
 
-      <%# 配送について %>
       <div class="items-detail">
         <div class="weight-bold-text question-text">
           <span>配送について</span>
@@ -82,9 +75,7 @@
           <%= f.collection_select(:day_id, Day.all, :id, :day, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
         </div>
       </div>
-      <%# /配送について %>
 
-      <%# 販売価格 %>
       <div class="sell-price">
         <div class="weight-bold-text question-text">
           <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -113,9 +104,7 @@
           </div>
         </div>
       </div>
-      <%# /販売価格 %>
 
-      <%# 注意書き %>
       <div class="caution">
         <p class="sentence">
           <a href="#">禁止されている出品、</a>
@@ -133,13 +122,10 @@
           に同意したことになります。
         </p>
       </div>
-      <%# /注意書き %>
-      <%# 下部ボタン %>
       <div class="sell-btn-contents">
         <%= f.submit "変更する" ,class:"sell-btn" %>
         <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
       </div>
-      <%# /下部ボタン %>
     <% end %>
   </div>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,145 +5,143 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path(@item.id), local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%= render partial: "shared/error_messages", locals: {model: f.object} %>
 
-    <%# 出品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        出品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <%# 出品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          出品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      <%# /出品画像 %>
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
+      <%# 商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:category_id, Category.all, :id, :category, {}, {class:"select-box", id:"item-category"}) %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:condition_id, Condition.all, :id, :condition, {}, {class:"select-box", id:"item-sales-status"}) %>
+        </div>
+      </div>
+      <%# /商品の詳細 %>
+
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:charge_id, Charge.all, :id, :charge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :prefecture, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:day_id, Day.all, :id, :day, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
+      </div>
+      <%# /配送について %>
+
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
+    <% end %>
   </div>
-  <% end %>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
- 商品情報編集機能を実装しました。
- 重複した記述を1つにまとめ、items_controller.rbの49行目を削除しました。

# Why
Furimaにて、商品情報の編集を行えるようにするため。

- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/8df77beb850709bbe6c63b7b26890740

- 正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/a080fb2f410d37684d4e9f1c0508a41a

- 入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/b3d62adc522e216d41b2cfbc652ed1a8

- 何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/0f1aafee00db1af3bde2a50bffca4007

- ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/1ac4302cf26532afca28d6e6689bd53f

- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/b802d534c9c3ec640d116bec3536b24a

- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/8df77beb850709bbe6c63b7b26890740
